### PR TITLE
Add link to PnPConvert.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Repository Contents
 * **/Software** - The various versions of the Windows based Charm High software
 * **/User-Manuals** - Various manuals from different machines in an attempt to piece together various poorly translated or documented features
 
+Related Projects
+----------------
+
+* [PNPConvert](https://github.com/hydra/pnpconvert) Conversion utility with DipTrace support, written in Groovy.
+
 License Information
 -------------------
 


### PR DESCRIPTION
This codebase didn't support my current favorite EDA tool, DipTrace. So I wrote a utility to work with the CSV files that DipTrace exports and published it as an open-source project.

This PR simply adds a link to it so others can find it.