### PR TITLE
first version of a setup.py

### DIFF
--- a/KiCad-Conversion/convert.py
+++ b/KiCad-Conversion/convert.py
@@ -24,10 +24,16 @@ from collections import OrderedDict
 
 import pyexcel
 
-from Feeder import Feeder
-from ICTray import ICTray
-from PartPlacement import PartPlacement
-from FileOperations import FileOperations
+try: # WOw, that so ugly... I don't know how to import modules to keep compat with 'python convert.py' and with the new cli call...
+    from Feeder import Feeder
+    from ICTray import ICTray
+    from PartPlacement import PartPlacement
+    from FileOperations import FileOperations
+except ImportError:
+    from .Feeder import Feeder
+    from .ICTray import ICTray
+    from .PartPlacement import PartPlacement
+    from .FileOperations import FileOperations
 
 available_feeders = [] # List of available feeders from user's CSV
 ic_trays = []
@@ -612,7 +618,7 @@ def main(component_position_file, feeder_config_file, cuttape_config_file, outfi
     if bom_output_file is not None:
         generate_bom(bom_output_file)
 
-if __name__ == '__main__':
+def cli():
     parser = argparse.ArgumentParser(description='Process pos files from KiCAD to this nice, CharmHigh software')
     parser.add_argument('component_position_file', type=str, help='KiCAD position file in ASCII')
     parser.add_argument('feeder_config_file', type=str, help='Feeder definition file. Supported file formats : csv, ods, fods, xls, xlsx,...')
@@ -634,3 +640,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     main(args.component_position_file, args.feeder_config_file, args.cuttape_config_file, args.output, args.include_unassigned_components, args.offset, args.mirror_x, args.board_width, args.bom_file)
+
+
+if __name__ == '__main__':
+    cli()

--- a/KiCad-Conversion/setup.py
+++ b/KiCad-Conversion/setup.py
@@ -1,0 +1,42 @@
+import os
+from setuptools import setup, find_packages
+
+# Utility function to read the README file.
+# Used for the long_description.  It's nice, because now 1) we have a top level
+# README file and 2) it's easier to type in the README file than to put a raw
+# string in below ...
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+requirements = ['pyexcel', 'pyexcel-odsr', 'pyexcel-xls']
+
+setup(
+    name = "kicad2charmhigh",
+    version = "0.0.1",
+    
+    # packages=find_packages(),
+    # py_modules = ["convert", "Feeder", "FileOperations", "ICTray", "PartPlacement"],
+    package_dir={'kicad2charmhigh': '.'},
+    packages=['kicad2charmhigh'],
+    # package_dir = {'kicad2charmhigh': '.'},
+    install_requires=requirements,
+    entry_points={
+        'console_scripts': [
+            'kicad2charmhigh=kicad2charmhigh.convert:cli',
+        ],
+    },
+
+    author = "Vivien Henry",
+    # author_email = "vivien.henry@outlook.fr",
+    # keywords = "example documentation tutorial",
+    # url = "http://packages.python.org/an_example_pypi_project",
+    description = ("This takes a KiCad POS file and converts it to a CharmHigh desktop pick and place work file"),
+    license = "MIT",
+    long_description=read('README.md'),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Topic :: Utilities",
+        # "License :: OSI Approved :: BSD License",
+    ],
+)


### PR DESCRIPTION
Hi all,
I am tired of long paths to invoke the convert.py tools in kicad...
Shall we make it a real python package ? In that way it could be installed with pip, pipenv, virtualenv, even distributed on pypi !

I did my best for the setup.py, it keeps the python convert.py call working, and it can be installed on a venv via pipenv (didn't try on my system based  install of python)

It can't be installed on pipenv in -e (editor) mode, because of the hierarchy of the project:

The bbest and cleanest options would be to move all the code under kicad2charmhigh folder (in a package mode) and then use automatic setuptools tools to find the package... In that way it would be fully python compliant !

Best,
Vivien