### PR TITLE
Kicad conversion script feeder height fix

### DIFF
--- a/KiCad-Conversion/convert.py
+++ b/KiCad-Conversion/convert.py
@@ -301,7 +301,6 @@ def load_component_info(component_position_file, offset, mirror_x, board_width):
                 components[componentCount].use_vision = feeder.use_vision
                 components[componentCount].height = feeder.height
 
-
                 # Add any global corrections (offset)
                 components[componentCount].y = components[componentCount].y + offset[1]
                 components[componentCount].x = components[componentCount].x + offset[0]

--- a/KiCad-Conversion/convert.py
+++ b/KiCad-Conversion/convert.py
@@ -299,6 +299,8 @@ def load_component_info(component_position_file, offset, mirror_x, board_width):
                 components[componentCount].place_component = feeder.place_component
                 components[componentCount].check_vacuum = feeder.check_vacuum
                 components[componentCount].use_vision = feeder.use_vision
+                components[componentCount].height = feeder.height
+
 
                 # Add any global corrections (offset)
                 components[componentCount].y = components[componentCount].y + offset[1]


### PR DESCRIPTION
Convert.py was not respecting the heights set in the feeder file. Updated load component info to include the height provided in the feeder document.